### PR TITLE
refactor: enhance error handling in technical career creation to mana…

### DIFF
--- a/src/AcadEvalSys.WEB/AcadEvalSys.WEB.Client/src/features/administration/services/technical-career-service.ts
+++ b/src/AcadEvalSys.WEB/AcadEvalSys.WEB.Client/src/features/administration/services/technical-career-service.ts
@@ -23,11 +23,19 @@ export const technicalCareerService = {
   },
 
   async create(career: CreateTechnicalCareerRequest): Promise<string> {
-    const { data } = await api.post<{ id: string }>(
-      TECHNICAL_CAREERS_API_URL,
-      career
-    );
-    return data.id;
+    try {
+      const { data } = await api.post<{ id: string }>(
+        TECHNICAL_CAREERS_API_URL,
+        career
+      );
+      return data.id;
+    } catch (error: any) {
+      // Si el servidor responde 201, consideramos que es un éxito
+      if (error.response?.status === 201) {
+        return error.response.data?.id || '';
+      }
+      throw error;
+    }
   },
 
   async update(

--- a/src/AcadEvalSys.WEB/AcadEvalSys.WEB.Client/src/features/careers/services/technical-career-service.ts
+++ b/src/AcadEvalSys.WEB/AcadEvalSys.WEB.Client/src/features/careers/services/technical-career-service.ts
@@ -32,11 +32,19 @@ export const technicalCareerService = {
   },
 
   async create(career: CreateTechnicalCareerRequest): Promise<string> {
-    const { data } = await api.post<{ id: string }>(
-      TECHNICAL_CAREERS_API_URL,
-      career
-    );
-    return data.id;
+    try {
+      const { data } = await api.post<{ id: string }>(
+        TECHNICAL_CAREERS_API_URL,
+        career
+      );
+      return data.id;
+    } catch (error: any) {
+      // Si el servidor responde 201, consideramos que es un éxito
+      if (error.response?.status === 201) {
+        return error.response.data?.id || '';
+      }
+      throw error;
+    }
   },
 
   async update(


### PR DESCRIPTION
…ge server response inconsistencies

## 📄: Descripción

_Proporciona una breve descripción de los cambios realizados en este PR. Explica el problema que resuelve o la funcionalidad que agrega._

- Cambios realizados:
  - Describe los principales cambios implementados.
  - Incluye detalles técnicos o ejemplos relevantes si es necesario.

## 📎: Lista de Verificación

Revisa y marca cada ítem para asegurarte de que el PR esté completo.

- [ ] El código sigue los estándares y convenciones establecidos.
- [ ] Se han añadido nuevas pruebas unitarias (si aplica).
- [ ] La documentación relevante ha sido actualizada (README, comentarios en el código, etc.).
- [ ] Se ha realizado pruebas locales para asegurar el correcto funcionamiento.
- [ ] Los cambios no introducen problemas de seguridad ni de rendimiento.

## ✔️: Cómo Probar Este Cambio

_Explica los pasos necesarios para probar este cambio, como comandos a ejecutar, archivos de configuración necesarios, etc._

1. Paso 1: Configura...
2. Paso 2: Ejecuta...
3. Paso 3: Verifica los resultados esperados...

## 📸: Capturas de Pantalla (Opcional)

_Si este PR incluye cambios en la UI o visuales, adjunta capturas de pantalla o GIFs._

## 🔗: Enlaces Adicionales

_Si aplica, agrega enlaces a documentación externa, discusiones relevantes o ejemplos similares._

## ⏰: Consideraciones Especiales

_Menciona cualquier detalle importante a considerar antes de aprobar este PR. Por ejemplo: nuevas dependencias, riesgos potenciales o ajustes necesarios en el futuro._

## 🟥: Problemas Relacionados

Cierra #123 (reemplaza 123 con el número del problema relacionado).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make technical career creation robust by treating 201 responses surfaced as errors as successful and returning the created id in both admin and careers services.
> 
> - **Services**:
>   - `features/administration/services/technical-career-service.ts`
>     - Update `create` to wrap POST in `try/catch`, treating `error.response.status === 201` as success and returning `id`.
>   - `features/careers/services/technical-career-service.ts`
>     - Same `create` logic to handle 201-as-success and return `id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ee7a6cd35894ff1cee7bb7b34add76183e46fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->